### PR TITLE
fix the additional  '\'

### DIFF
--- a/src/Console/Traits/DirectoryHelper.php
+++ b/src/Console/Traits/DirectoryHelper.php
@@ -28,7 +28,13 @@ trait DirectoryHelper
 
         $withFile = ($withFile) ? '\\' . $withFile : '';
         $semicolon = ($semicolon) ? ';' : '';
-
+        
+        // if(the user enter a repository name with no prefix)
+        if(count($pathArray) == 0){
+            // delete the '\' at the end of $directory to avoid the additional '\'
+            $directory =substr($directory, 0, -1);
+        }
+ 
         return 'App\\Http\\' . $directory . implode('\\', $pathArray) . $withFile . $semicolon;
     }
 


### PR DESCRIPTION
 
        // When the user enters a repository name with no prefix like: "php artisan repository:create cart"
        // if the following check is missing then, the $pathArray will be empty,
        // and then the implode('\\', $pathArray) -which is in the return statement- will return an empty string ==> '' ,
        // and because $directory ends with '\' -see the call of this function in CreateRepository class- the following will happen:
        // 1) in case of $interfaceNameSpace and $repositoryNameSpace -which was declared in CreateRepository class- will
        //    end with '\;'   ex:  "App\Http\Interfaces\;" and "App\Http\Repositories\;"  respectivly which will case syntax error.
        // 2)  in the case of $interfaceNameSpaceWithFileAndSemicolon -which was declared in CreateRepository class- will
        //    end will have '\\' after Interfaces  ex: "App\Http\Interfaces\\cartInterface" and will case syntax error in cartRepository.php file
        //    when attempting to use it with the use statement